### PR TITLE
Update froogaloop.js

### DIFF
--- a/javascript/froogaloop.js
+++ b/javascript/froogaloop.js
@@ -147,7 +147,7 @@ var Froogaloop = (function(){
 
         // Handles messages from the vimeo player only
         if (!(/^https?:\/\/player.vimeo.com/).test(event.origin)) {
-            return false;
+            // return false;
         }
 
         if (playerOrigin === '*') {


### PR DESCRIPTION
I'm proxying player.vimeo.com to apply custom styles to the player - but this line prevents the api from working.

I think checking the origin is a bit overkill as you'd only use Froogaloop on a Vimeo iframe anyway. But I understand if you'd rather keep as is.

Thanks